### PR TITLE
Fix file path issues in the regression test under Visual Studio 2015.

### DIFF
--- a/BytecodeTranslator/Program.cs
+++ b/BytecodeTranslator/Program.cs
@@ -24,6 +24,7 @@ using System.Text.RegularExpressions;
 using BytecodeTranslator.TranslationPlugins;
 using BytecodeTranslator.TranslationPlugins.BytecodeTranslator;
 using BytecodeTranslator.TranslationPlugins.PhoneTranslator;
+using System.Text;
 
 namespace BytecodeTranslator {
 
@@ -261,25 +262,19 @@ namespace BytecodeTranslator {
       return 0;
     }
 
-    public static int TranslateAssemblyAndWriteOutput(List<string> assemblyNames, HeapFactory heapFactory, Options options, List<Regex> exemptionList, bool whiteList) {
+    public static string TranslateAssemblyAndReturnOutput(List<string> assemblyNames, HeapFactory heapFactory, Options options, List<Regex> exemptionList, bool whiteList) {
       Contract.Requires(assemblyNames != null);
       Contract.Requires(heapFactory != null);
-      try {
-        var pgm = TranslateAssembly(assemblyNames, heapFactory, options, exemptionList, whiteList);
-        var fileName = assemblyNames[0];
-        fileName = Path.GetFileNameWithoutExtension(fileName);
-        string outputFileName = fileName + ".bpl";
-        using (var writer = new Microsoft.Boogie.TokenTextWriter(outputFileName)) {
-          Prelude.Emit(writer);
-          pgm.Emit(writer);
-          writer.Close();
-        }
-        return 0; // success
-      } catch (Exception e) { // swallow everything and just return an error code
-        Console.WriteLine("The byte-code translator failed: {0}", e.Message);
-        // Console.WriteLine("Stack trace: {0}", e.StackTrace);
-        return -1;
+      var pgm = TranslateAssembly(assemblyNames, heapFactory, options, exemptionList, whiteList);
+      var fileName = assemblyNames[0];
+      fileName = Path.GetFileNameWithoutExtension(fileName);
+      string outputFileName = fileName + ".bpl";
+      var sb = new StringBuilder();
+      using (var writer = new Microsoft.Boogie.TokenTextWriter(outputFileName, new StringWriter(sb), false)) {
+        Prelude.Emit(writer);
+        pgm.Emit(writer);
       }
+      return sb.ToString();
     }
 
     public static Bpl.Program/*?*/ TranslateAssembly(List<string> assemblyNames, HeapFactory heapFactory, Options options, List<Regex> exemptionList, bool whiteList) {

--- a/RegressionTests/TranslationTest/UnitTest0.cs
+++ b/RegressionTests/TranslationTest/UnitTest0.cs
@@ -38,6 +38,9 @@ namespace TranslationTest {
       }
     }
 
+    private string InputAssemblyPath =>
+      typeof(RegressionTestInput.Class0).Assembly.Location;
+
     #region Additional test attributes
     //
     // You can use the following additional attributes as you write your tests:
@@ -64,42 +67,33 @@ namespace TranslationTest {
       var options = new Options();
       options.monotonicHeap = true;
       options.dereference = Options.Dereference.Assume;
-      BCT.TranslateAssemblyAndWriteOutput(new List<string> { assemblyName }, heapFactory, options, null, false);
-      var fileName = Path.ChangeExtension(assemblyName, "bpl");
-      var s = File.ReadAllText(fileName);
-      return s;
+      return BCT.TranslateAssemblyAndReturnOutput(new List<string> { assemblyName }, heapFactory, options, null, false);
+    }
+
+    private void ComparisonTest(string name, Heap heap)
+    {
+      Stream resource = typeof(UnitTest0).Assembly.GetManifestResourceStream(
+        "TranslationTest." + name + "Input.txt");
+      StreamReader reader = new StreamReader(resource);
+      string expected = reader.ReadToEnd();
+      var result = ExecuteTest(InputAssemblyPath, new SplitFieldsHeap());
+      if (result != expected)
+      {
+        string resultFile = Path.Combine(TestContext.DeploymentDirectory, name + "Output.txt");
+        File.WriteAllText(resultFile, result);
+        var msg = String.Format("Output didn't match: {0}Input.txt \"{1}\"", name, resultFile);
+        Assert.Fail(msg);
+      }
     }
 
     [TestMethod]
     public void SplitFieldsHeap() {
-      string dir = TestContext.DeploymentDirectory;
-      var fullPath = Path.Combine(dir, "RegressionTestInput.dll");
-      Stream resource = typeof(UnitTest0).Assembly.GetManifestResourceStream("TranslationTest.SplitFieldsHeapInput.txt");
-      StreamReader reader = new StreamReader(resource);
-      string expected = reader.ReadToEnd();
-      var result = ExecuteTest(fullPath, new SplitFieldsHeap());
-      if (result != expected) {
-        string resultFile = Path.GetFullPath("SplitFieldsHeapOutput.txt");
-        File.WriteAllText(resultFile, result);
-        var msg = String.Format("Output didn't match: SplitFieldsHeapInput.txt \"{0}\"", resultFile);
-        Assert.Fail(msg);
-      }
+      ComparisonTest("SplitFieldsHeap", new SplitFieldsHeap());
     }
 
     [TestMethod]
     public void GeneralHeap() {
-      string dir = TestContext.DeploymentDirectory;
-      var fullPath = Path.Combine(dir, "RegressionTestInput.dll");
-      Stream resource = typeof(UnitTest0).Assembly.GetManifestResourceStream("TranslationTest.GeneralHeapInput.txt");
-      StreamReader reader = new StreamReader(resource);
-      string expected = reader.ReadToEnd();
-      var result = ExecuteTest(fullPath, new GeneralHeap());
-      if (result != expected) {
-        string resultFile = Path.GetFullPath("GeneralHeapOutput.txt");
-        File.WriteAllText(resultFile, result);
-        var msg = String.Format("Output didn't match: GeneralHeapInput.txt \"{0}\"", resultFile);
-        Assert.Fail(msg);
-      }
+      ComparisonTest("GeneralHeap", new GeneralHeap());
     }
 
   }


### PR DESCRIPTION
The test was looking for RegressionTestInput.dll in the test output
directory without having copied it there, and it was writing the actual
outputs to TranslationTest\bin\Debug instead of the test output directory.
I'm not sure how this was supposed to work before, but hopefully this
change does not break any other use modes.
