### PR TITLE
Fix evaluation order of assignments to fields.

### DIFF
--- a/BytecodeTranslator/ExpressionTraverser.cs
+++ b/BytecodeTranslator/ExpressionTraverser.cs
@@ -1076,16 +1076,19 @@ namespace BytecodeTranslator
 
       var/*?*/ field = container as IFieldReference;
       if (field != null) {
-        this.Traverse(source);
-        var e = this.TranslatedExpressions.Pop();
         var f = Bpl.Expr.Ident(this.sink.FindOrCreateFieldVariable(field));
         if (instance == null) {
+          this.Traverse(source);
+          var e = this.TranslatedExpressions.Pop();
           // static fields are not kept in the heap
           StmtTraverser.StmtBuilder.Add(Bpl.Cmd.SimpleAssign(tok, f, e));
         }
         else {
           this.Traverse(instance);
           var x = this.TranslatedExpressions.Pop();
+          // The source must be evaluated after the instance.
+          this.Traverse(source);
+          var e = this.TranslatedExpressions.Pop();
           var boogieType = sink.CciTypeToBoogie(field.Type);
           this.sink.Heap.WriteHeap(tok, x, f, e,
             field.ResolvedField.ContainingType.ResolvedType.IsStruct ? AccessType.Struct : AccessType.Heap,


### PR DESCRIPTION
Example program that demonstrates the incorrect translation by BCT:

``` csharp
using System;
using System.Diagnostics.Contracts;

public class Program
{
    class Cell
    {
        public int data;
    }
    static int last = 0;
    static Cell LHS(Cell cell)
    {
        last = 1;
        return cell;
    }
    static int RHS()
    {
        last = 2;
        return 42;
    }
    public static void Main()
    {
        Cell c = new Cell();
        LHS(c).data = RHS();
        Console.WriteLine(last);
        Contract.Assert(last == 2);
    }
}
```
